### PR TITLE
Fix Ville Skyttä's name

### DIFF
--- a/xslide3.el
+++ b/xslide3.el
@@ -4,7 +4,7 @@
 ;; Author: Tony Graham <tkg@menteith.com>
 ;; Contributors: Simon Brooke, Girard Milmeister, Norman Walsh,
 ;;               Moritz Maass, Lassi Tuura, Simon Wright, KURODA Akira,
-;;               Ville Skytt�, Glen Peterson
+;;               Ville Skyttä, Glen Peterson
 ;; Created: 29 July 2011
 ;; Keywords: languages, xsl, xml
 


### PR DESCRIPTION
Somehow the ä had turned into a � (U+FFFD REPLACEMENT CHARACTER).
Since this is beyond mojibake, I recovered the proper text from:
    https://github.com/emacsattic/xslide/blob/master/xslide.el
which had an otherwise-identical list of contributors at the top.